### PR TITLE
Added support for YAML pipeline resources

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -27,13 +27,12 @@
             "command": "${workspaceRoot}\\node_modules\\.bin\\tfx",
             "type": "shell",
             "args": [
-                "extension ",
+                "extension",
                 "create",
                 "--json",
                 "--root",
                 "${workspaceRoot}",
-                "--manifest-globs",
-                ""
+                "--manifest-globs"
             ],
             "presentation": {
                 "echo": true,


### PR DESCRIPTION
Fixes #60 

This PR only support pipeline option of all the YAML resources flavor currently available.
Pipeline resources from multiple projects are supported (cross-organization is not supported).

It also fixes an issue where the VS Code `package` task was not producing a VSIX file as output.